### PR TITLE
fix: Disable armhf platform in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,8 @@ website: https://github.com/astral-sh/ruff
 platforms:
   amd64:
   arm64:
-  armhf:
+  # Disabled until we can fix https://github.com/snapcrafters/ruff/issues/117
+  # armhf:
   ppc64el:
   riscv64:
   s390x:


### PR DESCRIPTION
Commented out armhf platform due to unresolved issue.