### PR TITLE
docs: update workflow badge links [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <p align="center">
 <a href="https://snapcraft.io/ruff"><img src="https://snapcraft.io/ruff/badge.svg" alt="Snap Status"></a>
-<a href="https://github.com/snapcrafters/ruff/actions/workflows/sync-version-with-upstream.yaml"><img src="https://github.com/snapcrafters/ruff/actions/workflows/sync-version-with-upstream.yaml/badge.svg"></a>
-<a href="https://github.com/snapcrafters/ruff/actions/workflows/release-to-candidate.yaml"><img src="https://github.com/snapcrafters/ruff/actions/workflows/release-to-candidate.yaml/badge.svg"></a>
-<a href="https://github.com/snapcrafters/ruff/actions/workflows/promote-to-stable.yaml"><img src="https://github.com/snapcrafters/ruff/actions/workflows/promote-to-stable.yaml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/ruff/actions/workflows/sync-version-with-upstream.yml"><img src="https://github.com/snapcrafters/ruff/actions/workflows/sync-version-with-upstream.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/ruff/actions/workflows/release-to-candidate.yml"><img src="https://github.com/snapcrafters/ruff/actions/workflows/release-to-candidate.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/ruff/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/ruff/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </p>
 
 ## Install


### PR DESCRIPTION
## Summary
- Updates README workflow badge links to point at the canonical renamed workflow files.
- Keeps badge href and image URLs aligned with the standard `.yml` workflow filenames.

## Files
- `README.md`

## Replacements
- `promote-to-stable.yaml -> promote-to-stable.yml`
- `release-to-candidate.yaml -> release-to-candidate.yml`
- `sync-version-with-upstream.yaml -> sync-version-with-upstream.yml`

## Verification
- `git diff --check`
- Commit message includes `[skip ci]`.

@jnsgruk please review.
